### PR TITLE
Get SurveyCTO forms and their fields dynamically

### DIFF
--- a/DAGs/helpers/postgres_utils.py
+++ b/DAGs/helpers/postgres_utils.py
@@ -90,29 +90,29 @@ class PostgresOperations:
             column_name = column_data.get('db_name')
 
         if column_data.get('type', '').lower() == 'int':
-            column_map = column_name + ' INT'
+            column_map = '\"' + column_name + '\" INT'
 
         elif column_data.get('type', '').lower() == 'decimal':
-            column_map = column_name + ' REAL'
+            column_map = '\"' + column_name + '\" REAL'
 
         elif column_data.get('type', '').lower() == 'char':
-            column_map = column_name + ' CHAR(' + str(column_data.get('length', 100)) + ')'
+            column_map = '\"' + column_name + '\" CHAR(' + str(column_data.get('length', 100)) + ')'
 
         elif column_data.get('type', '').lower() == 'boolean':
-            column_map = column_name + ' BOOLEAN'
+            column_map = '\"' + column_name + '\" BOOLEAN'
 
         elif column_data.get('type', '').lower() == 'boolean':
-            column_map = column_name + ' BOOLEAN'
+            column_map = '\"' + column_name + '\" BOOLEAN'
 
         elif column_data.get('type', '').lower() == 'array':
-            column_map = column_name + ' text[]'
+            column_map = '\"' + column_name + '\" text[]'
 
         elif column_data.get('type', '').lower() == 'object' or \
                 column_data.get('type', '').lower() == 'json':
-            column_map = column_name + ' jsonb'
+            column_map = '\"' + column_name + '\" jsonb'
 
         else:
-            column_map = column_name + ' TEXT'
+            column_map = '\"' + column_name + '\" TEXT'
 
         if column_name.lower() == str(primary_key).lower():
             column_map = '{} UNIQUE'.format(column_map)

--- a/DAGs/helpers/postgres_utils.py
+++ b/DAGs/helpers/postgres_utils.py
@@ -50,14 +50,13 @@ class PostgresOperations:
         :param target_column: reference column for update
         :return full_upsert_query_string:  complete UPSERT query string
         """
-        insert_query_string = 'INSERT INTO \"' + table_name + '\" (' + ','\
-            .join(columns) + ')'
+        insert_query_string = 'INSERT INTO \"' + table_name + '\" (\"' + '\", \"'.join(columns) + '\")'
         db_field_maps = ['%({})s'.format(item) for item in columns]
-        exclude_columns = ['{}=excluded.{}'.format(column, column) for column in columns]
-        update_string = 'ON CONFLICT ({}) '.format(target_column) +\
+        exclude_columns = ['\"{}\"=excluded.\"{}\"'.format(column, column) for column in columns]
+        update_string = 'ON CONFLICT (\"{}\") '.format(target_column) +\
                         'DO UPDATE SET ' + ', '.join(exclude_columns)
 
-        full_upsert_query_string = insert_query_string + 'VALUES (' + ','.join(
+        full_upsert_query_string = insert_query_string + ' VALUES (' + ','.join(
             db_field_maps) + ') ' + update_string
 
         return full_upsert_query_string

--- a/DAGs/helpers/postgres_utils.py
+++ b/DAGs/helpers/postgres_utils.py
@@ -37,9 +37,8 @@ class PostgresOperations:
         :param columns_data: the data column names
         :return create_table_query: SQL query string
         """
-        create_table_query = 'CREATE TABLE IF NOT EXISTS ' \
-                             + table_name + ' (' + ', '.join(columns_data) + ')'
-
+        create_table_query = 'CREATE TABLE IF NOT EXISTS \"' \
+                             + table_name + '\" (' + ', '.join(columns_data) + ')'
         return create_table_query
 
     @staticmethod
@@ -51,7 +50,7 @@ class PostgresOperations:
         :param target_column: reference column for update
         :return full_upsert_query_string:  complete UPSERT query string
         """
-        insert_query_string = 'INSERT INTO ' + table_name + '(' + ','\
+        insert_query_string = 'INSERT INTO \"' + table_name + '\" (' + ','\
             .join(columns) + ')'
         db_field_maps = ['%({})s'.format(item) for item in columns]
         exclude_columns = ['{}=excluded.{}'.format(column, column) for column in columns]

--- a/DAGs/helpers/utils.py
+++ b/DAGs/helpers/utils.py
@@ -111,7 +111,11 @@ class DataCleaningUtil:
         """
         columns = [item.get('name') or item.get('db_name') for item in fields]
         for row_data in list(data):
-            row_columns = row_data.keys()
+            if row_data is not None:
+                row_columns = list(row_data.keys())
+                
+            else:
+                row_columns = []
 
             missing_columns = list(set(columns) - set(row_columns))
 
@@ -123,10 +127,11 @@ class DataCleaningUtil:
                             fields
                         )
                     )
-                    row_data.setdefault(
-                        column,
-                        cls.set_column_defaults(field_obj.get('type', None))
-                    )
+                    if row_data is not None:
+                        row_data.setdefault(
+                            column,
+                            cls.set_column_defaults(field_obj.get('type', None))
+                        )
         return data
 
     @staticmethod

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -85,7 +85,7 @@ def get_form_data(form):
                        '|'.join(form.get('statuses', ['approved', 'pending'])))
 
     response = fetch_data(url, form.get('keyfile'))
-    response_data = response.json()
+    response_data = response
 
     logger.info('Get form data successful')
 

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -94,6 +94,24 @@ def get_forms():
 
     auth_basic = requests.auth.HTTPBasicAuth(SURV_USERNAME, SURV_PASSWORD)
     # TODO add a retry mechanism on this first request
+    forms_request = session.get(
+        f'https://{SURV_SERVER_NAME}.surveycto.com/console/forms-groups-datasets/get',
+        auth=auth_basic,
+        headers={
+            "X-csrf-token": csrf_token,
+            'X-OpenRosa-Version': '1.0',
+            "Accept": "*/*"
+        }
+    )
+
+    if forms_request.status_code != 200:
+        logger.error(forms_request.text)
+        logger.error('Could not retrieve the list of forms')
+
+    forms = forms_request.json()['forms']
+    # ! Is this filter really working?
+    forms = list(filter(lambda x: x['testForm'] == False and x['deployed'] == True, forms))
+
 def get_form_data(form):
     """
     load form data from SurveyCTO API

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -1,5 +1,6 @@
 import logging
 import requests
+import re
 from datetime import timedelta
 
 from airflow import DAG, AirflowException
@@ -74,6 +75,25 @@ def get_form_url(form_id, last_date, status):
     return form_url
 
 
+def get_forms():
+    """
+    List the schema and fields of the forms
+    # TODO Flatten the fields
+    # TODO convert fields types properly
+    """
+    session = requests.Session()
+    # Get CSRF token
+    try:
+        res = session.get(f'https://{SURV_SERVER_NAME}.surveycto.com/')
+        res.raise_for_status()
+        csrf_token = re.search(r"var csrfToken = '(.+?)';", res.text).group(1)
+    except requests.exceptions.HTTPError as e:
+        logger.error('Couldn\'t load SurveyCTO landing page for getting the CSRF token')
+    except requests.exceptions.RequestException as e:
+        logger.error('Unexpected error loading SurveyCTO landing page')
+
+    auth_basic = requests.auth.HTTPBasicAuth(SURV_USERNAME, SURV_PASSWORD)
+    # TODO add a retry mechanism on this first request
 def get_form_data(form):
     """
     load form data from SurveyCTO API

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -175,7 +175,7 @@ def get_forms():
 
             forms_structures.append({
                 'form_id': form.get('id'),
-                'name': form.get('title').replace('.', '__').replace(' ', '__').replace('-', '__').replace(',', '__').replace(':', '__').replace('(', '__').replace(')', '__').replace('&', '__').replace('/', '__'), # Removing spaces for PostgreSQL
+                'name': form.get('title'),
                 'unique_column': 'KEY__', # https://docs.surveycto.com/05-exporting-and-publishing-data/01-overview/09.data-format.html
                 'fields': fields,
                 'statuses': ['approved', 'pending'],
@@ -262,7 +262,7 @@ def save_data_to_db(**kwargs):
                 with connection:
                     cur = connection.cursor()
                     if SURV_RECREATE_DB == 'True':
-                        cur.execute("DROP TABLE IF EXISTS " + form.get('name'))
+                        cur.execute("DROP TABLE IF EXISTS \"" + form.get('name') + "\"")
                         cur.execute(db_query)
 
                     # insert data

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -295,6 +295,7 @@ def save_data_to_db(**kwargs):
             logger.warn('The form {} has no data'.format(form.get('name')))
 
     if total_success_forms == total_forms:
+        logger.info(f'Loaded submissions of all the {total_forms} forms')
         return dict(success=True)
     else:
         logger.error(f'Only {total_success_forms} forms loaded out of a total of {total_forms} forms')

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -3,7 +3,7 @@ import requests
 import re
 from datetime import timedelta
 
-from airflow import DAG
+from airflow import DAG, AirflowException
 from airflow.operators.python_operator import PythonOperator
 from helpers.utils import (DataCleaningUtil, logger)
 from helpers.mongo_utils import MongoOperations

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -112,6 +112,26 @@ def get_forms():
     # ! Is this filter really working?
     forms = list(filter(lambda x: x['testForm'] == False and x['deployed'] == True, forms))
 
+    forms_structures = []
+    for form in forms:
+        form_id = form.get('id')
+        form_details = session.get(
+            f'https://{SURV_SERVER_NAME}.surveycto.com/forms/{form_id}/workbook/export/load',
+            params={
+                'includeFormStructureModel': 'true',
+                'submissionsPattern': 'all',
+                'fieldsPattern': 'all',
+                'fetchInBatches': 'true',
+                'includeDatasets': 'false',
+                'date': '1550011019966' # TODO set date conveniently
+            },
+            auth=auth_basic,
+            headers={
+                "X-csrf-token": csrf_token,
+                'X-OpenRosa-Version': '1.0',
+                "Accept": "*/*"
+            }
+        )
 def get_form_data(form):
     """
     load form data from SurveyCTO API

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -202,6 +202,11 @@ def get_form_data(form):
     response = fetch_data(url, form.get('keyfile'))
     response_data = response
 
+    for submission in response_data:
+        # Below raises an error if the preious request fails with 500 (string indices must be integers)
+        submission['KEY__'] = submission['KEY'] # ! Not it's place. No idea what the primary_key is
+        del submission['KEY']
+
     logger.info('Get form data successful')
 
     return response_data

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -202,14 +202,14 @@ def get_form_data(form):
 
     response = fetch_data(url, form.get('keyfile'))
 
-    for submission in response_data:
-        # Below raises an error if the preious request fails with 500 (string indices must be integers)
-        submission['KEY__'] = submission['KEY'] # ! Not it's place. No idea what the primary_key is
+    for submission in response:
+        # The unique column identifying submissions is KEY__
+        submission['KEY__'] = submission['KEY']
         del submission['KEY']
 
     logger.info('Get form data successful')
 
-    return response_data
+    return response
 
 
 def save_data_to_db(**kwargs):
@@ -239,12 +239,11 @@ def save_data_to_db(**kwargs):
         ]
 
         if isinstance(response_data, (list, )) and len(response_data):
-
             if SURV_DBMS is not None and (SURV_DBMS.lower() == 'postgres'
                                           or SURV_DBMS.lower().replace(
                                               ' ', '') == 'postgresdb'):
                 """
-                Dump data to postgres 
+                Dump data to postgres
                 """
 
                 # create the column strings

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -145,7 +145,7 @@ def get_forms():
             } for field in fields]
             # Adding the KEY__ field
             fields.append({
-                'name': 'KEY__',
+                'name': 'KEY',
                 'type': 'text'
             })
             forms_structures.append({
@@ -174,14 +174,7 @@ def get_form_data(form):
 
     url = get_form_url(form.get('form_id', ''), form.get('last_date', 0),
                        '|'.join(form.get('statuses', ['approved', 'pending'])))
-
     response = fetch_data(url, form.get('keyfile'))
-
-    for submission in response:
-        # The unique column identifying submissions is KEY__
-        submission['KEY__'] = submission['KEY']
-        del submission['KEY']
-
     logger.info('Get form data successful')
 
     return response

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -132,6 +132,29 @@ def get_forms():
                 "Accept": "*/*"
             }
         )
+        if form_details.status_code == 200:
+            form_structure_model = form_details.json().get('formStructureModel')
+            first_language = form_structure_model.get('defaultLanguage')
+            fields = form_structure_model['summaryElementsPerLanguage'][first_language]['children']
+
+            # Convert/transform fields to our format
+            # fields = list(map(convert_surveycto_field, fields))
+            fields = [{
+                'name': field.get('name').lower(),
+                'type': 'text' # ! Defaulting all fields to TEXT PostgreSQL type
+            } for field in fields]
+            # Adding the KEY__ field
+            fields.append({
+                'name': 'KEY__',
+                'type': 'text'
+            })
+
+            new_fields = []
+            for field in fields:
+                new_fields_names = [field.get('name') for field in new_fields]
+                if field.get('name') not in new_fields_names:
+                    new_fields.append(field)
+            fields = new_fields
 def get_form_data(form):
     """
     load form data from SurveyCTO API

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -173,6 +173,22 @@ def get_forms():
                 if '.' in name:
                     field['name'] = name.replace('.', '__')
 
+            forms_structures.append({
+                'form_id': form.get('id'),
+                'name': form.get('title').replace('.', '__').replace(' ', '__').replace('-', '__').replace(',', '__').replace(':', '__').replace('(', '__').replace(')', '__').replace('&', '__').replace('/', '__'), # Removing spaces for PostgreSQL
+                'unique_column': 'KEY__', # https://docs.surveycto.com/05-exporting-and-publishing-data/01-overview/09.data-format.html
+                'fields': fields,
+                'statuses': ['approved', 'pending'],
+                # 'last_date': form.get('lastIncomingDataDate'), # TODO Should never be 0 or will cause API restrictions
+                'last_date': 1549736155, # TODO Should never be 0 or will cause API restrictions
+            })
+        else:
+            logger.error(form_details.text)
+            logger.error(f'Could not retrieve details of the form {form_id}')
+
+    return forms_structures
+
+
 def get_form_data(form):
     """
     load form data from SurveyCTO API

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -140,7 +140,7 @@ def get_forms():
             # Convert/transform fields to our format
             # fields = list(map(convert_surveycto_field, fields))
             fields = [{
-                'name': field.get('name').lower(),
+                'name': field.get('name'),
                 'type': 'text' # ! Defaulting all fields to TEXT PostgreSQL type
             } for field in fields]
             # Adding the KEY__ field
@@ -148,35 +148,10 @@ def get_forms():
                 'name': 'KEY__',
                 'type': 'text'
             })
-
-            new_fields = []
-            for field in fields:
-                new_fields_names = [field.get('name') for field in new_fields]
-                if field.get('name') not in new_fields_names:
-                    new_fields.append(field)
-            fields = new_fields
-
-            # Rename fields with PostgreSQL reserved words and
-            # remove special characters from fields names
-            for field in fields:
-                name = field.get('name')
-                if name == 'end':
-                    field['name'] = 'end__'
-                if name == 'zone':
-                    field['name'] = 'zone__'
-                if name == 'into':
-                    field['name'] = 'into__'
-                if name == 'when':
-                    field['name'] = 'when__'
-                if '-' in name:
-                    field['name'] = name.replace('-', '__')
-                if '.' in name:
-                    field['name'] = name.replace('.', '__')
-
             forms_structures.append({
                 'form_id': form.get('id'),
                 'name': form.get('title'),
-                'unique_column': 'KEY__', # https://docs.surveycto.com/05-exporting-and-publishing-data/01-overview/09.data-format.html
+                'unique_column': 'KEY', # https://docs.surveycto.com/05-exporting-and-publishing-data/01-overview/09.data-format.html
                 'fields': fields,
                 'statuses': ['approved', 'pending'],
                 # 'last_date': form.get('lastIncomingDataDate'), # TODO Should never be 0 or will cause API restrictions
@@ -226,7 +201,6 @@ def save_data_to_db(**kwargs):
         # get columns
         if form.get('fields') is not None:
             columns = [item.get('name') for item in form.get('fields', [])]
-            columns = list(dict.fromkeys(columns)) # Remove duplicates from columns
         else:
             columns = []
         primary_key = form.get('unique_column')

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -155,6 +155,24 @@ def get_forms():
                 if field.get('name') not in new_fields_names:
                     new_fields.append(field)
             fields = new_fields
+
+            # Rename fields with PostgreSQL reserved words and
+            # remove special characters from fields names
+            for field in fields:
+                name = field.get('name')
+                if name == 'end':
+                    field['name'] = 'end__'
+                if name == 'zone':
+                    field['name'] = 'zone__'
+                if name == 'into':
+                    field['name'] = 'into__'
+                if name == 'when':
+                    field['name'] = 'when__'
+                if '-' in name:
+                    field['name'] = name.replace('-', '__')
+                if '.' in name:
+                    field['name'] = name.replace('.', '__')
+
 def get_form_data(form):
     """
     load form data from SurveyCTO API

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -60,13 +60,13 @@ def fetch_data(data_url, enc_key_file=None):
                                      files=files,
                                      auth=requests.auth.HTTPBasicAuth(
                                          SURV_USERNAME, SURV_PASSWORD))
-
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        raise AirflowException(f'Fetch data failed with exception: {e}')
     except Exception as e:
-        logger.error('Fetching data from SurveyCTO failed')
-        logger.exception(e)
-        response_data = dict(success=False, error=e)
+        raise AirflowException(f'Unexpected error when fetching data: {e}')
 
-    return response_data
+    return response.json()
 
 
 def get_form_url(form_id, last_date, status):
@@ -201,7 +201,6 @@ def get_form_data(form):
                        '|'.join(form.get('statuses', ['approved', 'pending'])))
 
     response = fetch_data(url, form.get('keyfile'))
-    response_data = response
 
     for submission in response_data:
         # Below raises an error if the preious request fails with 500 (string indices must be integers)


### PR DESCRIPTION
## What is the Purpose?
Given a SurveyCTO server, load the forms details, and their fields.
This schema will be later used to load data into a database.

## What was the approach?
What the function `get_forms` in the SurveyCTO DAG does, roughly, is:
1. Authenticate to SurveyCTO and get a CSRF token
2. Make request for the list of all forms
3. For each of the above forms, get details about its fields
4. Create a table for each form, with columns representing its fields
5. Make a request for the submissions of each form, and save them to the form's table

## Are there any concerns to addressed further before or after merging this PR?
This can be merged after testing that it does not break any other working DAG, since I made some changes on the shared code of PostgreSQL.

Among the various issues still to adress:
- PostgresSQL limitations on the table name and column names, and the conflicts they might raise
- Requests retries
- Requests rate-limiting
- Error handling of requests and others

## Mentions?
@sannleen @michaelbukachi 

## Issue(s) affected?
Related to:
- https://github.com/hikaya-io/connectors/issues/19
- https://github.com/hikaya-io/data-pipeline/issues/90
- https://github.com/hikaya-io/data-pipeline/issues/97