### PR TITLE
SurveyCTO: map fields types to PostgreSQL column types

### DIFF
--- a/DAGs/helpers/configs.py
+++ b/DAGs/helpers/configs.py
@@ -48,7 +48,6 @@ SURV_USERNAME = Variable.get('SURV_USERNAME', default_var='')
 SURV_MONGO_URI = Variable.get('SURV_MONGO_URI', default_var='')
 SURV_DBMS = Variable.get('SURV_DBMS', default_var=None)
 SURV_MONGO_DB_NAME = Variable.get('SURV_MONGO_DB_NAME', default_var='')
-SURV_RECREATE_DB = Variable.get('SURV_RECREATE_DB', default_var=False)
 
 """
 ONA Variables

--- a/DAGs/helpers/postgres_utils.py
+++ b/DAGs/helpers/postgres_utils.py
@@ -70,7 +70,8 @@ class PostgresOperations:
         :param values: list reference values to be deleted
         :return query: the DELETE query string
         """
-        query = 'DELETE FROM {}'.format(table) + ' WHERE ' + \
+        # TODO doublequote columns in below query
+        query = 'DELETE FROM \"{}'.format(table) + '\" WHERE ' + \
                 column + '= ANY(Array[' + ', '.join(["'{}'".format(str(item)) for item in values]) + '])'
 
         return query
@@ -147,7 +148,7 @@ class PostgresOperations:
         primary_key_values_list = []
         with connection:
             cursor = connection.cursor()
-            cursor.execute("DECLARE super_cursor BINARY CURSOR FOR SELECT " + primary_key + " FROM " + form)
+            cursor.execute("DECLARE super_cursor BINARY CURSOR FOR SELECT \"" + primary_key + "\" FROM \"" + form + "\"")
 
             while True:
                 cursor.execute("FETCH 1000 FROM super_cursor")

--- a/DAGs/helpers/postgres_utils.py
+++ b/DAGs/helpers/postgres_utils.py
@@ -88,26 +88,31 @@ class PostgresOperations:
         if column_name is None:
             column_name = column_data.get('db_name')
 
-        if column_data.get('type', '').lower() == 'int':
+        if column_data.get('type', '') is None:
+            field_type = ''
+        else:
+            field_type = column_data.get('type', '').lower()
+
+        # TODO time formats
+        # TODO select_one, select_multiple
+        # TODO Geopoints
+
+        if field_type in ['int', 'integer']:
             column_map = '\"' + column_name + '\" INT'
 
-        elif column_data.get('type', '').lower() == 'decimal':
+        elif field_type == 'decimal':
             column_map = '\"' + column_name + '\" REAL'
 
-        elif column_data.get('type', '').lower() == 'char':
+        elif field_type == 'char':
             column_map = '\"' + column_name + '\" CHAR(' + str(column_data.get('length', 100)) + ')'
 
-        elif column_data.get('type', '').lower() == 'boolean':
+        elif field_type == 'boolean':
             column_map = '\"' + column_name + '\" BOOLEAN'
 
-        elif column_data.get('type', '').lower() == 'boolean':
-            column_map = '\"' + column_name + '\" BOOLEAN'
-
-        elif column_data.get('type', '').lower() == 'array':
+        elif field_type == 'array':
             column_map = '\"' + column_name + '\" text[]'
 
-        elif column_data.get('type', '').lower() == 'object' or \
-                column_data.get('type', '').lower() == 'json':
+        elif field_type in ['object', 'json']:
             column_map = '\"' + column_name + '\" jsonb'
 
         else:
@@ -143,4 +148,3 @@ class PostgresOperations:
                 primary_key_values_list = primary_key_values_list + row_ids
 
         return primary_key_values_list
-

--- a/DAGs/helpers/postgres_utils.py
+++ b/DAGs/helpers/postgres_utils.py
@@ -70,9 +70,8 @@ class PostgresOperations:
         :param values: list reference values to be deleted
         :return query: the DELETE query string
         """
-        # TODO doublequote columns in below query
-        query = 'DELETE FROM \"{}'.format(table) + '\" WHERE ' + \
-                column + '= ANY(Array[' + ', '.join(["'{}'".format(str(item)) for item in values]) + '])'
+        query = 'DELETE FROM \"{}'.format(table) + '\" WHERE \"' + \
+                column + '\"= ANY(Array[' + ', '.join(["'{}'".format(str(item)) for item in values]) + '])'
 
         return query
 

--- a/DAGs/helpers/postgres_utils.py
+++ b/DAGs/helpers/postgres_utils.py
@@ -115,6 +115,14 @@ class PostgresOperations:
         elif field_type in ['object', 'json']:
             column_map = '\"' + column_name + '\" jsonb'
 
+        # Converting dates, times, and datetimes
+        elif field_type == 'datetime':
+            column_map = '\"' + column_name + '\" timestamp'
+        elif field_type == 'date':
+            column_map = '\"' + column_name + '\" date'
+        elif field_type == 'time':
+            column_map = '\"' + column_name + '\" time'
+
         else:
             column_map = '\"' + column_name + '\" TEXT'
 

--- a/DAGs/helpers/postgres_utils.py
+++ b/DAGs/helpers/postgres_utils.py
@@ -123,6 +123,11 @@ class PostgresOperations:
         elif field_type == 'time':
             column_map = '\"' + column_name + '\" time'
 
+        elif field_type == 'select_one':
+            column_map = '\"' + column_name + '\" TEXT'
+        elif field_type == 'select_multiple':
+            column_map = '\"' + column_name + '\" TEXT []'
+
         else:
             column_map = '\"' + column_name + '\" TEXT'
 

--- a/DAGs/helpers/utils.py
+++ b/DAGs/helpers/utils.py
@@ -74,28 +74,31 @@ class DataCleaningUtil:
         return flat_json_data
 
     @staticmethod
-    def set_column_defaults(type):
+    def set_column_defaults(column_type):
         """
         Set data column default values for missing columns
-        : param type: data type
+        : param column_type: column type
         : return column_string: Postgres query compatible string
         """
 
         return None
 
-        if type.lower() == 'decimal':
+        if column_type.lower() in ['int', 'integer']:
             return None
 
-        if type.lower() == 'char':
+        if column_type.lower() == 'decimal':
+            return None
+
+        if column_type.lower() == 'char':
             return ''
 
-        if type.lower() == 'boolean':
+        if column_type.lower() == 'boolean':
             return None
 
-        if type.lower() == 'array':
+        if column_type.lower() == 'array':
             return None
 
-        if type.lower() == 'object' or type.lower() == 'json':
+        if column_type.lower() == 'object' or column_type.lower() == 'json':
             return None
 
         else:

--- a/DAGs/helpers/utils.py
+++ b/DAGs/helpers/utils.py
@@ -80,29 +80,10 @@ class DataCleaningUtil:
         : param column_type: column type
         : return column_string: Postgres query compatible string
         """
-
-        return None
-
-        if column_type.lower() in ['int', 'integer']:
-            return None
-
-        if column_type.lower() == 'decimal':
-            return None
-
         if column_type.lower() == 'char':
             return ''
-
-        if column_type.lower() == 'boolean':
-            return None
-
-        if column_type.lower() == 'array':
-            return None
-
-        if column_type.lower() == 'object' or column_type.lower() == 'json':
-            return None
-
         else:
-            return ''
+            return None
 
     @classmethod
     def update_row_columns(cls, fields, data):

--- a/DAGs/helpers/utils.py
+++ b/DAGs/helpers/utils.py
@@ -80,8 +80,8 @@ class DataCleaningUtil:
         : param type: data type
         : return column_string: Postgres query compatible string
         """
-        if type.lower() == 'int':
-            return None
+
+        return None
 
         if type.lower() == 'decimal':
             return None

--- a/DAGs/helpers/variables_template.json
+++ b/DAGs/helpers/variables_template.json
@@ -8,7 +8,6 @@
   "SURV_MONGO_DB_NAME": "mongoDB name to connect to",
   "SURV_MONGO_URI": "mongo connection URI:- mongodb://username:password@host/db_name",
   "SURV_PASSWORD": "SurveyCTO server password",
-  "SURV_RECREATE_DB": "Enable creation of a table when True, or just data dumping when False",
   "SURV_SERVER_NAME": "SurveyCTO server",
   "SURV_USERNAME": "SurveyCTO username",
   "SURV_FORMS": [

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -157,6 +157,20 @@ def get_forms():
                 'name': 'SubmissionDate',
                 'type': 'datetime'
             })
+            # Adding other fields
+            fields.append({
+                'name': 'formdef_version',
+                'type': 'text'
+            })
+            fields.append({
+                'name': 'review_quality',
+                'type': 'text'
+            })
+            fields.append({
+                'name': 'review_status',
+                'type': 'text'
+            })
+
             forms_structures.append({
                 'form_id': form.get('id'),
                 'name': form.get('title'),

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -144,32 +144,38 @@ def get_forms():
                 'type': field.get('dataType')
             } for field in fields]
             # Adding the KEY__ field
-            fields.append({
-                'name': 'KEY',
-                'type': 'text'
-            })
+            if 'KEY' not in fields_names: # !Fetched in flattening
+                fields.append({
+                    'name': 'KEY',
+                    'type': 'text'
+                })
+            if 'CompletionDate' not in fields_names:
             # Adding the CompletionDate/SubmissionDate datetime fields
-            fields.append({
-                'name': 'CompletionDate',
-                'type': 'datetime'
-            })
-            fields.append({
-                'name': 'SubmissionDate',
-                'type': 'datetime'
-            })
-            # Adding other fields
-            fields.append({
-                'name': 'formdef_version',
-                'type': 'text'
-            })
-            fields.append({
-                'name': 'review_quality',
-                'type': 'text'
-            })
-            fields.append({
-                'name': 'review_status',
-                'type': 'text'
-            })
+                fields.append({
+                    'name': 'CompletionDate',
+                    'type': 'datetime'
+                })
+            if 'SubmissionDate' not in fields_names: # !Fetched in flattening
+                fields.append({
+                    'name': 'SubmissionDate',
+                    'type': 'datetime'
+                })
+            if 'formdef_version' not in fields_names: # !Fetched in flattening
+                # Adding other fields
+                fields.append({
+                    'name': 'formdef_version',
+                    'type': 'text'
+                })
+            if 'review_quality' not in fields_names:
+                fields.append({
+                    'name': 'review_quality',
+                    'type': 'text'
+                })
+            if 'review_status' not in fields_names:
+                fields.append({
+                    'name': 'review_status',
+                    'type': 'text'
+                })
 
             forms_structures.append({
                 'form_id': form.get('id'),

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -263,7 +263,7 @@ def save_data_to_db(**kwargs):
                         # TODO Group all the fields by types and do transformations on them
                         integer_columns = [field.get('name') for field in form.get('fields') if field.get('type') == 'integer']
                         select_multiple_columns = [field.get('name') for field in form.get('fields') if field.get('type') == 'select_multiple']
-                        # datetime_columns = [field.get('name') for field in form.get('fields') if field.get('type') in ['date', 'time', 'datetime']]
+                        datetime_columns = [field.get('name') for field in form.get('fields') if field.get('type') in ['date', 'time', 'datetime']]
                         for col in integer_columns: # Set default and null values for integers in the submission
                             try:
                                 if submission[col] == '':
@@ -281,7 +281,12 @@ def save_data_to_db(**kwargs):
                                 # else: # TODO convert the column into an array
                             except KeyError:
                                 submission[col] = None
-
+                        for col in datetime_columns:
+                            try:
+                                if submission[col] == '':
+                                    submission[col] = None
+                            except KeyError: # Column is missing from a submission
+                                submission[col] = None
                     if form.get('fields') is not None:
                         cur.executemany(
                             upsert_query,

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -245,7 +245,7 @@ def save_data_to_db(**kwargs):
 
                 # create the Db
                 db_query = PostgresOperations.construct_postgres_create_table_query(
-                    form.get('name'), column_data)
+                    form.get('form_id'), column_data)
 
                 connection = PostgresOperations.establish_postgres_connection(
                     POSTGRES_DB)
@@ -253,12 +253,12 @@ def save_data_to_db(**kwargs):
                 with connection:
                     cur = connection.cursor()
 
-                    cur.execute("DROP TABLE IF EXISTS \"" + form.get('name') + "\"")
+                    cur.execute("DROP TABLE IF EXISTS \"" + form.get('form_id') + "\"")
                     cur.execute(db_query)
 
                     # insert data
                     upsert_query = PostgresOperations.construct_postgres_upsert_query(
-                        form.get('name'), columns, primary_key)
+                        form.get('form_id'), columns, primary_key)
 
                     for submission in response_data:
                         # TODO Group all the fields by types and do transformations on them
@@ -346,13 +346,13 @@ def sync_db_with_server(**context):
                 connection = PostgresOperations.establish_postgres_connection(
                     POSTGRES_DB)
                 db_data_keys = PostgresOperations.get_all_row_ids_in_db(
-                    connection, primary_key, form.get('name'))
+                    connection, primary_key, form.get('form_id'))
 
                 deleted_ids = list(set(db_data_keys) - set(api_data_keys))
                 if len(deleted_ids) > 0:
                     # remove deleted items from the db
                     query_string = PostgresOperations.construct_postgres_delete_query(
-                        form.get('name'), primary_key, deleted_ids)
+                        form.get('form_id'), primary_key, deleted_ids)
 
                     with connection:
                         cur = connection.cursor()
@@ -363,7 +363,7 @@ def sync_db_with_server(**context):
 
                         deleted_items.append(
                             dict(keys=deleted_ids,
-                                 table=form.get('name'),
+                                 table=form.get('form_id'),
                                  number_of_items=len(deleted_ids)))
 
                     deleted_data.append(dict(success=deleted_items))

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -17,7 +17,6 @@ from helpers.configs import (
     SURV_FORMS,
     SURV_DBMS,
     SURV_MONGO_DB_NAME,
-    SURV_RECREATE_DB,
     SURV_MONGO_URI,
     POSTGRES_DB,
 )
@@ -253,9 +252,9 @@ def save_data_to_db(**kwargs):
 
                 with connection:
                     cur = connection.cursor()
-                    if SURV_RECREATE_DB == 'True':
-                        cur.execute("DROP TABLE IF EXISTS \"" + form.get('name') + "\"")
-                        cur.execute(db_query)
+
+                    cur.execute("DROP TABLE IF EXISTS \"" + form.get('name') + "\"")
+                    cur.execute(db_query)
 
                     # insert data
                     upsert_query = PostgresOperations.construct_postgres_upsert_query(

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -257,8 +257,6 @@ def save_data_to_db(**kwargs):
 
                 with connection:
                     cur = connection.cursor()
-
-                    cur.execute("DROP TABLE IF EXISTS \"" + form.get('form_id') + "\"")
                     cur.execute(db_query)
 
                     # insert data

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -228,7 +228,7 @@ def save_data_to_db(**kwargs):
             for item in api_data
         ]
 
-        if isinstance(response_data, (list, )) and len(response_data):
+        if isinstance(response_data, (list, )):
             if SURV_DBMS is not None and (SURV_DBMS.lower() == 'postgres'
                                           or SURV_DBMS.lower().replace(
                                               ' ', '') == 'postgresdb'):

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -148,6 +148,15 @@ def get_forms():
                 'name': 'KEY',
                 'type': 'text'
             })
+            # Adding the CompletionDate/SubmissionDate datetime fields
+            fields.append({
+                'name': 'CompletionDate',
+                'type': 'datetime'
+            })
+            fields.append({
+                'name': 'SubmissionDate',
+                'type': 'datetime'
+            })
             forms_structures.append({
                 'form_id': form.get('id'),
                 'name': form.get('title'),

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -263,6 +263,8 @@ def save_data_to_db(**kwargs):
                     for submission in response_data:
                         # TODO Group all the fields by types and do transformations on them
                         integer_columns = [field.get('name') for field in form.get('fields') if field.get('type') == 'integer']
+                        select_multiple_columns = [field.get('name') for field in form.get('fields') if field.get('type') == 'select_multiple']
+                        # datetime_columns = [field.get('name') for field in form.get('fields') if field.get('type') in ['date', 'time', 'datetime']]
                         for col in integer_columns: # Set default and null values for integers in the submission
                             try:
                                 if submission[col] == '':
@@ -273,6 +275,13 @@ def save_data_to_db(**kwargs):
                                 submission[col] = None
                             except ValueError:
                                 logger.error('Field is not convertible to integer')
+                        for col in select_multiple_columns:
+                            try:
+                                if submission[col] == '':
+                                    submission[col] = [] # ? Should it?
+                                # else: # TODO convert the column into an array
+                            except KeyError:
+                                submission[col] = None
 
                     if form.get('fields') is not None:
                         cur.executemany(

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -14,7 +14,6 @@ from helpers.configs import (
     SURV_SERVER_NAME,
     SURV_USERNAME,
     SURV_PASSWORD,
-    SURV_FORMS,
     SURV_DBMS,
     SURV_MONGO_DB_NAME,
     SURV_MONGO_URI,
@@ -327,7 +326,8 @@ def sync_db_with_server(**context):
     if success_dump.get('success'):
         deleted_items = []
         deleted_data = []
-        for form in SURV_FORMS:
+        forms = get_forms()
+        for form in forms:
             primary_key = form.get('unique_column')
 
             response_data = [

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -80,7 +80,7 @@ def get_forms():
     # TODO Flatten the fields
     # TODO convert fields types properly
     """
-    session = create_requests_session(debug=True)
+    session = create_requests_session(debug=False)
     # Get CSRF token
     try:
         res = session.get(f'https://{SURV_SERVER_NAME}.surveycto.com/')

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -141,7 +141,7 @@ def get_forms():
             # fields = list(map(convert_surveycto_field, fields))
             fields = [{
                 'name': field.get('name'),
-                'type': 'text' # ! Defaulting all fields to TEXT PostgreSQL type
+                'type': field.get('dataType')
             } for field in fields]
             # Adding the KEY__ field
             fields.append({

--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ Below is how the form list should look
 ````
 `SURV_DBMS = ''` :- Database management system to dump the data (mongo/mongodb, postgres/postgresdb)
 
-`SURV_RECREATE_DB = ''` :- set if you want new tables to be always created isntead of updating the values
-
 ## Upload the Variables from a json file
 Download the `variables_template.json` on this repo and update it with the correct values.
 


### PR DESCRIPTION
## What is the Purpose?
Address issue https://github.com/hikaya-io/data-pipeline/issues/104

## What was the approach?
- Saved integer fields as such and handled conversion of them in submission data and setting default values
- Same for decimals/floats
- Same for date, time and datetime values
- Added following fields to all forms: `CompletionDate`, `SubmissionDate`, `formdef_version`, `review_quality`, `review_status`

## Are there any concerns to addressed further before or after merging this PR?
Not all the types are properly converted. Some of the ones missing are:

- `geopoint`, `geoshape`, `geotrace` SurveyCTO types
- `barcode`, `image`, `audio`, `video`...

## Mentions?
@sannleen @michaelbukachi 

## Issue(s) affected?
Fix https://github.com/hikaya-io/data-pipeline/issues/104