### PR TITLE
PoC: Load SurveyCTO submissions from CSV source into Pandas

### DIFF
--- a/DAGs/helpers/postgres_utils_sqlalchemy.py
+++ b/DAGs/helpers/postgres_utils_sqlalchemy.py
@@ -1,0 +1,51 @@
+import sqlalchemy
+from sqlalchemy import (
+    create_engine,
+    Table,
+    Column,
+    Integer,
+    String,
+    MetaData,
+    ForeignKey,
+)
+
+
+class PostgresOperations:
+    def __init__(self, user, password, host, port, database):
+        self.engine = create_engine(
+            f"postgresql+psycopg2://{user}:{password}@{host}:{port}/{database}",
+            echo=True,
+        )
+
+    def create_database(name):
+        print("create database")
+
+    def create_table(self, name, columns):
+        """Create a Postgres table
+
+        Args:
+            name (string): Name of the table
+            columns (array): array of dicts, each defining `name` of the field and its `type`
+                Allowed field types are the following: `string`, `integer`, `float`, `foreign_key?!` # TODO
+                # TODO Primary keys, nullability, foreign keys
+        """
+        try:
+            metadata = MetaData()
+            columns = []
+            table = Table(name, metadata, *columns)
+            metadata.create_all(self.engine)
+
+            return table
+        except e:
+            print('Exception')
+            print(e)
+
+    def upsert(table, value, on_conflict):
+        """Upsert a value into a table
+
+        Args:
+            table ([type]): [description]
+            value ([type]): [description]
+            on_conflict ([type]): key(s) on which to detect conflicting upserts
+        """
+        print("upsert")

--- a/DAGs/helpers/postgres_utils_sqlalchemy.py
+++ b/DAGs/helpers/postgres_utils_sqlalchemy.py
@@ -1,3 +1,10 @@
+#######################################################################
+#         WORK IN PROGRESS                                            #
+#   * Explore usage of SQLAlchemy Core, althoug saving submissions is #
+#   now one using pandas.to_sql function.                             #
+#   * Explore using SQLAlchemy core to separate DBs by server         #
+#######################################################################
+
 import sqlalchemy
 from sqlalchemy import (
     create_engine,
@@ -14,38 +21,6 @@ class PostgresOperations:
     def __init__(self, user, password, host, port, database):
         self.engine = create_engine(
             f"postgresql+psycopg2://{user}:{password}@{host}:{port}/{database}",
-            echo=True,
+            echo=False,
         )
 
-    def create_database(name):
-        print("create database")
-
-    def create_table(self, name, columns):
-        """Create a Postgres table
-
-        Args:
-            name (string): Name of the table
-            columns (array): array of dicts, each defining `name` of the field and its `type`
-                Allowed field types are the following: `string`, `integer`, `float`, `foreign_key?!` # TODO
-                # TODO Primary keys, nullability, foreign keys
-        """
-        try:
-            metadata = MetaData()
-            columns = []
-            table = Table(name, metadata, *columns)
-            metadata.create_all(self.engine)
-
-            return table
-        except e:
-            print('Exception')
-            print(e)
-
-    def upsert(table, value, on_conflict):
-        """Upsert a value into a table
-
-        Args:
-            table ([type]): [description]
-            value ([type]): [description]
-            on_conflict ([type]): key(s) on which to detect conflicting upserts
-        """
-        print("upsert")

--- a/DAGs/helpers/surveycto.py
+++ b/DAGs/helpers/surveycto.py
@@ -22,7 +22,15 @@ class SurveyCTO:
         Mainly used for logging in and generating a Python Requests session to make
         authenticated requests.
         """
-        pass
+        try:
+            res = self.session.get(f"https://{self.server_name}.surveycto.com/")
+            res.raise_for_status()
+            csrf_token = re.search(r"var csrfToken = '(.+?)';", res.text).group(1)
+            return csrf_token
+        except requests.exceptions.HTTPError as e:
+            raise e
+        except requests.exceptions.RequestException as e:
+            raise e
 
     def get_all_forms():
         """Get a list of all the forms of the SurveyCTO server

--- a/DAGs/helpers/surveycto.py
+++ b/DAGs/helpers/surveycto.py
@@ -59,9 +59,7 @@ class SurveyCTO:
                 f'https://{self.server_name}.surveycto.com/console/forms-groups-datasets/get',
                 auth=self.auth_basic,
                 headers={
-                    "X-csrf-token": self.csrf_token,
-                    'X-OpenRosa-Version': '1.0',
-                    "Accept": "*/*"
+                    "X-csrf-token": self.csrf_token
                 }
             )
         except HTTPError as e:
@@ -85,19 +83,9 @@ class SurveyCTO:
         try:
             form_details = self.session.get(
                 f"https://{self.server_name}.surveycto.com/forms/{id}/workbook/export/load",
-                params={
-                    "includeFormStructureModel": "true",
-                    "submissionsPattern": "all",
-                    "fieldsPattern": "all",
-                    "fetchInBatches": "true",
-                    "includeDatasets": "false",
-                    "date": "1550011019966",  # TODO set date conveniently
-                },
                 auth=self.auth_basic,
                 headers={
-                    "X-csrf-token": self.csrf_token,
-                    "X-OpenRosa-Version": "1.0",
-                    "Accept": "*/*",
+                    "X-csrf-token": self.csrf_token
                 },
             )
             return form_details.json()

--- a/DAGs/helpers/surveycto.py
+++ b/DAGs/helpers/surveycto.py
@@ -1,14 +1,23 @@
+import requests
+
+from helpers.requests import create_requests_session
 
 
 class SurveyCTO:
-    def __init__(self, surver_name, username=None, password=None):
-        self.surver_name = surver_name
-        # self.client
-        # Fetch the CSRF toke
+    # ? When to raise error of wrong credentials
+    # TODO get logger
+    # TODO remove usaeg of Airflow exceptions
+    # TODO to what shape should data be transfered to? Are we using pandas here?
+    # TODO encrypted forms?
+    def __init__(self, server_name, username=None, password=None):
+        self.server_name = server_name
+        
+        # Get Requests session, build authentication and get CSRF token
+        self.session = create_requests_session(debug=False) # ? Can authentication and CSRF token be baked into the session?
+        self.auth_basic = requests.auth.HTTPBasicAuth(username, password)
         self.csrf_token = self._get_CSRF_token()
-        # self.session = 
 
-    def _get_CSRF_token():
+    def _get_CSRF_token(self):
         """Get a CSRF token from the SurveyCTO home page.
         Mainly used for logging in and generating a Python Requests session to make
         authenticated requests.

--- a/DAGs/helpers/surveycto.py
+++ b/DAGs/helpers/surveycto.py
@@ -19,7 +19,7 @@ def csv_to_pandas(csv):
     return pandas.read_csv(StringIO(csv))
 
 class SurveyCTO:
-    # ? When to raise error of wrong credentials
+    # ? When to # raise error of wrong credentials
     # TODO get logger
     # TODO remove usaeg of Airflow exceptions
     # TODO to what shape should data be transfered to? Are we using pandas here?
@@ -100,6 +100,7 @@ class SurveyCTO:
                     "Accept": "*/*",
                 },
             )
+            return form_details.json()
         except HTTPError as e:
             logger.error(f'Error getting details of form of ID: {id}')
             logger.error(e)
@@ -109,7 +110,6 @@ class SurveyCTO:
             logger.error(e)
             raise e
 
-        return form_details.json()
 
     def get_form_submissions(self, id):
         """Get all submissions of a form

--- a/DAGs/helpers/surveycto.py
+++ b/DAGs/helpers/surveycto.py
@@ -1,0 +1,37 @@
+
+
+class SurveyCTO:
+    def __init__(self, surver_name, username=None, password=None):
+        self.surver_name = surver_name
+        # self.client
+        # Fetch the CSRF toke
+        self.csrf_token = self._get_CSRF_token()
+        # self.session = 
+
+    def _get_CSRF_token():
+        """Get a CSRF token from the SurveyCTO home page.
+        Mainly used for logging in and generating a Python Requests session to make
+        authenticated requests.
+        """
+        pass
+
+    def get_all_forms():
+        """Get a list of all the forms of the SurveyCTO server
+        """
+        pass
+
+    def get_form(id):
+        """Get a form by its ID
+
+        Args:
+            id (string): ID of the form
+        """
+        pass
+
+    def get_form_submissions(id):
+        """Get all submissions of a form
+
+        Args:
+            id (string): ID of the form
+        """
+        pass

--- a/DAGs/pull_survey_cto_data_csv.py
+++ b/DAGs/pull_survey_cto_data_csv.py
@@ -1,4 +1,3 @@
-from io import StringIO
 from datetime import timedelta
 import logging
 import re
@@ -8,18 +7,13 @@ import pandas
 
 from airflow import DAG, AirflowException
 from airflow.operators.python_operator import PythonOperator
-from helpers.utils import DataCleaningUtil, logger
-from helpers.mongo_utils import MongoOperations
+from helpers.utils import logger
 from helpers.postgres_utils import PostgresOperations
-from helpers.requests import create_requests_session
 from helpers.task_utils import notify, get_daily_start_date
 from helpers.configs import (
     SURV_SERVER_NAME,
     SURV_USERNAME,
     SURV_PASSWORD,
-    SURV_DBMS,
-    SURV_MONGO_DB_NAME,
-    SURV_MONGO_URI,
     POSTGRES_DB,
     POSTGRES_DB_PASSWORD,
     POSTGRES_USER,
@@ -31,10 +25,8 @@ from helpers.postgres_utils_sqlalchemy import PostgresOperations
 
 
 logger = logging.getLogger(__name__)
-
 DAG_NAME = "dots_survey_cto_data_csv_pipeline"
 PIPELINE = "surveycto"
-
 default_args = {
     "owner": "Hikaya-Dots",
     "depends_on_past": False,
@@ -45,119 +37,6 @@ default_args = {
     "on_failure_callback": notify(status="failed", pipeline=PIPELINE),
     "on_success_callback": notify(status="success", pipeline=PIPELINE),
 }
-
-
-def csv_to_pd(csv):
-    """
-    Parse a CSV string and loads it into a Pandas dataframe
-    """
-    return pandas.read_csv(StringIO(csv))
-
-
-def import_form_submissions(form):
-    """
-    CSV SCTO import documentation: https://docs.surveycto.com/05-exporting-and-publishing-data/01-overview/09.data-format.html
-    """
-    db = PostgresOperations(
-        POSTGRES_USER,
-        POSTGRES_DB_PASSWORD,
-        POSTGRES_HOST,
-        POSTGRES_PORT,
-        POSTGRES_DB,
-    )
-    form_id = form.get("id")
-    auth_basic = requests.auth.HTTPBasicAuth(SURV_USERNAME, SURV_PASSWORD)
-    # CSV direct
-    csv_url = f"https://{SURV_SERVER_NAME}.surveycto.com/api/v1/forms/data/csv/{form_id}?date=1616535957"
-    test = requests.get(csv_url, auth=auth_basic)
-
-    # Pandas loading
-    df = csv_to_pd(test.text)
-    print(df.head(5))
-    print(df.info())
-    print(df.describe())
-    # Save dataframe into PostgreSQL
-    df.to_sql(form_id, db.engine, if_exists="replace")
-
-    session = create_requests_session(debug=False)
-    try:
-        res = session.get(f"https://{SURV_SERVER_NAME}.surveycto.com/")
-        res.raise_for_status()
-        csrf_token = re.search(r"var csrfToken = '(.+?)';", res.text).group(1)
-    except requests.exceptions.HTTPError as e:
-        logger.error(e)
-        raise AirflowException(
-            "Couldn't load SurveyCTO landing page for getting the CSRF token"
-        )
-    except requests.exceptions.RequestException as e:
-        logger.error(e)
-        raise AirflowException("Unexpected error loading SurveyCTO landing page")
-
-    form_details = session.get(
-        f"https://{SURV_SERVER_NAME}.surveycto.com/forms/{form_id}/workbook/export/load",
-        params={
-            "includeFormStructureModel": "true",
-            "submissionsPattern": "all",
-            "fieldsPattern": "all",
-            "fetchInBatches": "true",
-            "includeDatasets": "false",
-            "date": "1550011019966",  # TODO set date conveniently
-        },
-        auth=auth_basic,
-        headers={
-            "X-csrf-token": csrf_token,
-            "X-OpenRosa-Version": "1.0",
-            "Accept": "*/*",
-        },
-    )
-    if form_details.status_code == 200:
-        form_details = form_details.json()
-        print(form_details)
-    else:
-        print(form_details)
-        print(form_details.text)
-
-    form_structure_model = form_details.get("formStructureModel")
-    first_language = form_structure_model.get("defaultLanguage")
-    fields = form_structure_model["summaryElementsPerLanguage"][first_language][
-        "children"
-    ]
-    print(fields)
-
-    repeat_fields = get_repeat_groups(fields)
-    print("repeat_fields")
-    print(repeat_fields)
-
-    for field in repeat_fields:
-        if field.get("dataType") == "repeat":
-            csv_url = f"https://{SURV_SERVER_NAME}.surveycto.com/api/v1/forms/data/csv/{form_id}/{field.get('name')}"
-            test = requests.get(csv_url, auth=auth_basic)
-            df = csv_to_pd(test.text)
-            print(df.shape)
-            print(df.head(5))
-            print(df.describe())
-            # Save dataframe into PostgreSQL
-            df.to_sql(form_id + "_" + field.get("name"), db.engine, if_exists="replace")
-
-            # Group repeat groups submissions by "PARENT KEY"
-            grouped = df.groupby("PARENT_KEY")
-            print(grouped)
-            print(grouped.head(5))
-            print(grouped.describe())
-
-
-def get_repeat_groups(fields):
-    """
-    Return an array of repeat groups and their details from a list of nested fields
-    """
-    repeat_fields = []
-    for field in fields:
-        if field.get("dataType") == "repeat":
-            repeat_fields.append(field)
-        elif field.get("children"):
-            # repeat_fields.append(get_repeat_groups(field.get("children")))
-            repeat_fields = repeat_fields + get_repeat_groups(field.get("children"))
-    return repeat_fields
 
 
 def import_forms_and_submissions(**kwargs):

--- a/DAGs/pull_survey_cto_data_csv.py
+++ b/DAGs/pull_survey_cto_data_csv.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 
 from airflow import DAG, AirflowException
 from airflow.operators.python_operator import PythonOperator
-from helpers.utils import (DataCleaningUtil, logger)
+from helpers.utils import DataCleaningUtil, logger
 from helpers.mongo_utils import MongoOperations
 from helpers.postgres_utils import PostgresOperations
 from helpers.requests import create_requests_session
@@ -22,22 +22,24 @@ from helpers.configs import (
 
 logger = logging.getLogger(__name__)
 
-DAG_NAME = 'dots_survey_cto_data_csv_pipeline'
-PIPELINE = 'surveycto'
+DAG_NAME = "dots_survey_cto_data_csv_pipeline"
+PIPELINE = "surveycto"
 
 default_args = {
-    'owner': 'Hikaya-Dots',
-    'depends_on_past': False,
-    'start_date': get_daily_start_date(),
-    'catchup': False,
-    'retries': 2,
-    'retry_delay': timedelta(minutes=5),
-    'on_failure_callback': notify(status='failed', pipeline=PIPELINE),
-    'on_success_callback': notify(status='success', pipeline=PIPELINE)
+    "owner": "Hikaya-Dots",
+    "depends_on_past": False,
+    "start_date": get_daily_start_date(),
+    "catchup": False,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": notify(status="failed", pipeline=PIPELINE),
+    "on_success_callback": notify(status="success", pipeline=PIPELINE),
 }
 
+
 def get_forms():
-    print('a')
+    print("a")
+
 
 def import_form_submissions(form):
     """
@@ -46,10 +48,7 @@ def import_form_submissions(form):
     # CSV direct
     csv_url = f"https://{SURV_SERVER_NAME}.surveycto.com/api/v1/forms/data/csv/{form.get('id')}"
     auth_basic = requests.auth.HTTPBasicAuth(SURV_USERNAME, SURV_PASSWORD)
-    test = requests.get(
-        csv_url,
-        auth=auth_basic
-    )
+    test = requests.get(csv_url, auth=auth_basic)
 
     # forms_request = session.get(
     #     f'https://{SURV_SERVER_NAME}.surveycto.com/console/forms-groups-datasets/get',
@@ -88,19 +87,18 @@ def import_form_submissions(form):
     print(df.info())
     print(df.describe())
 
-def import_forms_and_submissions(**kwargs):
-    import_form_submissions({
-        'id': 'airflow_sample_form'
-    })
 
-with DAG(DAG_NAME, default_args=default_args,
-         schedule_interval='@daily') as dag:
+def import_forms_and_submissions(**kwargs):
+    import_form_submissions({"id": "airflow_sample_form"})
+
+
+with DAG(DAG_NAME, default_args=default_args, schedule_interval="@daily") as dag:
 
     dag.doc_md = """
     Doc
     """
     t1 = PythonOperator(
-        task_id='Save_data_to_DB',
+        task_id="Save_data_to_DB",
         python_callable=import_forms_and_submissions,
         dag=dag,
     )

--- a/DAGs/pull_survey_cto_data_csv.py
+++ b/DAGs/pull_survey_cto_data_csv.py
@@ -71,7 +71,7 @@ def import_forms_and_submissions(**kwargs):
 
             for repeat_group in repeat_groups:
                 dataframe = scto_client.get_repeat_group_submissions(form["id"], repeat_group["name"])
-                dataframe.to_sql(form["id"], db.engine, if_exists="replace")
+                dataframe.to_sql(form["id"] + "___" + repeat_group["name"], db.engine, if_exists="replace")
                 logger.info(f"Saved repeat group {repeat_group['name']} of form {form['id']}")
 
             form_details = scto_client.get_form(form["id"])

--- a/DAGs/pull_survey_cto_data_csv.py
+++ b/DAGs/pull_survey_cto_data_csv.py
@@ -1,0 +1,116 @@
+import logging
+import requests
+import re
+from datetime import timedelta
+
+from airflow import DAG, AirflowException
+from airflow.operators.python_operator import PythonOperator
+from helpers.utils import (DataCleaningUtil, logger)
+from helpers.mongo_utils import MongoOperations
+from helpers.postgres_utils import PostgresOperations
+from helpers.requests import create_requests_session
+from helpers.task_utils import notify, get_daily_start_date
+from helpers.configs import (
+    SURV_SERVER_NAME,
+    SURV_USERNAME,
+    SURV_PASSWORD,
+    SURV_DBMS,
+    SURV_MONGO_DB_NAME,
+    SURV_MONGO_URI,
+    POSTGRES_DB,
+)
+
+logger = logging.getLogger(__name__)
+
+DAG_NAME = 'dots_survey_cto_data_csv_pipeline'
+PIPELINE = 'surveycto'
+
+default_args = {
+    'owner': 'Hikaya-Dots',
+    'depends_on_past': False,
+    'start_date': get_daily_start_date(),
+    'catchup': False,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=5),
+    'on_failure_callback': notify(status='failed', pipeline=PIPELINE),
+    'on_success_callback': notify(status='success', pipeline=PIPELINE)
+}
+
+def get_forms():
+    print('a')
+
+def import_form_submissions(form):
+    """
+    CSV SCTO import documentation: https://docs.surveycto.com/05-exporting-and-publishing-data/01-overview/09.data-format.html
+    """
+    # CSV direct
+    csv_url = f"https://{SURV_SERVER_NAME}.surveycto.com/api/v1/forms/data/csv/{form.get('id')}"
+    auth_basic = requests.auth.HTTPBasicAuth(SURV_USERNAME, SURV_PASSWORD)
+    test = requests.get(
+        csv_url,
+        auth=auth_basic
+    )
+
+    # forms_request = session.get(
+    #     f'https://{SURV_SERVER_NAME}.surveycto.com/console/forms-groups-datasets/get',
+    #     auth=auth_basic,
+    #     headers={
+    #         "X-csrf-token": csrf_token,
+    #         'X-OpenRosa-Version': '1.0',
+    #         "Accept": "*/*"
+    #     }
+    # )
+    # form_details = session.get(
+    #     f'https://{SURV_SERVER_NAME}.surveycto.com/forms/{form_id}/workbook/export/load',
+    #     params={
+    #         'includeFormStructureModel': 'true',
+    #         'submissionsPattern': 'all',
+    #         'fieldsPattern': 'all',
+    #         'fetchInBatches': 'true',
+    #         'includeDatasets': 'false',
+    #         'date': '1550011019966' # TODO set date conveniently
+    #     },
+    #     auth=auth_basic,
+    #     headers={
+    #         "X-csrf-token": csrf_token,
+    #         'X-OpenRosa-Version': '1.0',
+    #         "Accept": "*/*"
+    #     }
+    # )
+
+    from io import StringIO
+    import pandas
+
+    string_io = StringIO(test.text)
+    df = pandas.read_csv(string_io)
+    print(df.shape)
+    print(df.head(10))
+    print(df.info())
+    print(df.describe())
+
+def import_forms_and_submissions(**kwargs):
+    import_form_submissions({
+        'id': 'airflow_sample_form'
+    })
+
+with DAG(DAG_NAME, default_args=default_args,
+         schedule_interval='@daily') as dag:
+
+    dag.doc_md = """
+    Doc
+    """
+    t1 = PythonOperator(
+        task_id='Save_data_to_DB',
+        python_callable=import_forms_and_submissions,
+        dag=dag,
+    )
+
+    # t2 = PythonOperator(
+    #     task_id='Save_data_to_DB',
+    #     python_callable=import_forms_and_submissions,
+    #     dag=dag,
+    # )
+
+    # save_data_to_db_task >> sync_db_with_server_task
+    # t1 >> t2
+    t1

--- a/DAGs/pull_survey_cto_data_csv.py
+++ b/DAGs/pull_survey_cto_data_csv.py
@@ -45,51 +45,113 @@ def import_form_submissions(form):
     """
     CSV SCTO import documentation: https://docs.surveycto.com/05-exporting-and-publishing-data/01-overview/09.data-format.html
     """
-    # CSV direct
-    csv_url = f"https://{SURV_SERVER_NAME}.surveycto.com/api/v1/forms/data/csv/{form.get('id')}"
+    form_id = form.get("id")
     auth_basic = requests.auth.HTTPBasicAuth(SURV_USERNAME, SURV_PASSWORD)
+    # CSV direct
+    csv_url = (
+        f"https://{SURV_SERVER_NAME}.surveycto.com/api/v1/forms/data/csv/{form_id}"
+    )
     test = requests.get(csv_url, auth=auth_basic)
 
-    # forms_request = session.get(
-    #     f'https://{SURV_SERVER_NAME}.surveycto.com/console/forms-groups-datasets/get',
-    #     auth=auth_basic,
-    #     headers={
-    #         "X-csrf-token": csrf_token,
-    #         'X-OpenRosa-Version': '1.0',
-    #         "Accept": "*/*"
-    #     }
-    # )
-    # form_details = session.get(
-    #     f'https://{SURV_SERVER_NAME}.surveycto.com/forms/{form_id}/workbook/export/load',
-    #     params={
-    #         'includeFormStructureModel': 'true',
-    #         'submissionsPattern': 'all',
-    #         'fieldsPattern': 'all',
-    #         'fetchInBatches': 'true',
-    #         'includeDatasets': 'false',
-    #         'date': '1550011019966' # TODO set date conveniently
-    #     },
-    #     auth=auth_basic,
-    #     headers={
-    #         "X-csrf-token": csrf_token,
-    #         'X-OpenRosa-Version': '1.0',
-    #         "Accept": "*/*"
-    #     }
-    # )
-
+    # Pandas loading
     from io import StringIO
     import pandas
 
     string_io = StringIO(test.text)
     df = pandas.read_csv(string_io)
-    print(df.shape)
-    print(df.head(10))
+    # print(df.shape)
+    # print(df.head(5))
     print(df.info())
     print(df.describe())
 
+    session = create_requests_session(debug=False)
+    try:
+        res = session.get(f"https://{SURV_SERVER_NAME}.surveycto.com/")
+        res.raise_for_status()
+        csrf_token = re.search(r"var csrfToken = '(.+?)';", res.text).group(1)
+        print("csrf_token")
+        print(csrf_token)
+    except requests.exceptions.HTTPError as e:
+        logger.error(e)
+        raise AirflowException(
+            "Couldn't load SurveyCTO landing page for getting the CSRF token"
+        )
+    except requests.exceptions.RequestException as e:
+        logger.error(e)
+        raise AirflowException("Unexpected error loading SurveyCTO landing page")
+
+    form_details = session.get(
+        f"https://{SURV_SERVER_NAME}.surveycto.com/forms/{form_id}/workbook/export/load",
+        params={
+            "includeFormStructureModel": "true",
+            "submissionsPattern": "all",
+            "fieldsPattern": "all",
+            "fetchInBatches": "true",
+            "includeDatasets": "false",
+            "date": "1550011019966",  # TODO set date conveniently
+        },
+        auth=auth_basic,
+        headers={
+            "X-csrf-token": csrf_token,
+            "X-OpenRosa-Version": "1.0",
+            "Accept": "*/*",
+        },
+    )
+    if form_details.status_code == 200:
+        form_details = form_details.json()
+        print(form_details)
+    else:
+        print(form_details)
+        print(form_details.text)
+
+    form_structure_model = form_details.get("formStructureModel")
+    first_language = form_structure_model.get("defaultLanguage")
+    fields = form_structure_model["summaryElementsPerLanguage"][first_language][
+        "children"
+    ]
+    print(fields)
+
+    repeat_fields = get_repeat_groups(fields)
+    print("repeat_fields")
+    print(repeat_fields)
+
+    for field in repeat_fields:
+        if field.get("dataType") == "repeat":
+            print("Found a repeat group...===================")
+            print(field)
+            csv_url = f"https://{SURV_SERVER_NAME}.surveycto.com/api/v1/forms/data/csv/{form_id}/{field.get('name')}"
+            test = requests.get(csv_url, auth=auth_basic)
+            string_io = StringIO(test.text)
+            df = pandas.read_csv(string_io)
+            print(df.shape)
+            print(df.head(5))
+            print(df.describe())
+            # Group them by "PARENT KEY"
+            grouped = df.groupby("PARENT_KEY")
+            print("GROUPED")
+            print(grouped)
+            # print(grouped.shape)
+            print(grouped.head(5))
+            print(grouped.describe())
+
+
+def get_repeat_groups(fields):
+    """
+    Return an array of repeat groups and their details from a list of nested fields
+    """
+    repeat_fields = []
+    for field in fields:
+        if field.get("dataType") == "repeat":
+            repeat_fields.append(field)
+        elif field.get("children"):
+            # repeat_fields.append(get_repeat_groups(field.get("children")))
+            repeat_fields = repeat_fields + get_repeat_groups(field.get("children"))
+    return repeat_fields
+
 
 def import_forms_and_submissions(**kwargs):
-    import_form_submissions({"id": "airflow_sample_form"})
+    # import_form_submissions({"id": "airflow_sample_form"})
+    import_form_submissions({"id": "baseline_bmz_v1"})
 
 
 with DAG(DAG_NAME, default_args=default_args, schedule_interval="@daily") as dag:
@@ -102,13 +164,4 @@ with DAG(DAG_NAME, default_args=default_args, schedule_interval="@daily") as dag
         python_callable=import_forms_and_submissions,
         dag=dag,
     )
-
-    # t2 = PythonOperator(
-    #     task_id='Save_data_to_DB',
-    #     python_callable=import_forms_and_submissions,
-    #     dag=dag,
-    # )
-
-    # save_data_to_db_task >> sync_db_with_server_task
-    # t1 >> t2
     t1


### PR DESCRIPTION
# PoC
## What is the Purpose?
PoC for an alternative approach to load SCTO forms and submissions.

## What was the approach?

Unlike the previous method, where we load data from the API and in the wide format, I used the SurveyCTO CSV import feature to load submissions of a form, and a second endpoint to load the repeat groups separately. This seems to me to be the much superior approach, partly to handle repeat groups.

## Are there any concerns to addressed further before or after merging this PR?
- Explore using SQL Alchemy core to make PostgreSQL changes
- Can we store the repeat groups into separate tables and have them point to the form submissions using foreign keys? How does that play with Superset, or other tools we want to use on the data? @sannleen 

## Mentions?
@sannleen

## Issue(s) affected?
None