### PR TITLE
SCTO: Fix error on forms with incorrect IDs #42

### DIFF
--- a/DAGs/helpers/requests.py
+++ b/DAGs/helpers/requests.py
@@ -48,7 +48,7 @@ def create_requests_session(timeout=5, retries=3, debug=False):
 
     retry_strategy = Retry(
         total=retries,  
-        status_forcelist=[413, 429, 500, 502, 503, 504],
+        status_forcelist=[409, 413, 429, 500, 502, 503, 504],
         method_whitelist=["HEAD", "GET", "OPTIONS"],
         backoff_factor=1
     )

--- a/DAGs/helpers/surveycto.py
+++ b/DAGs/helpers/surveycto.py
@@ -4,8 +4,8 @@ from io import StringIO
 
 import requests
 from requests.exceptions import HTTPError
+from urllib.parse import quote
 import pandas
-from requests.exceptions import HTTPError, RequestException
 
 from helpers.requests import create_requests_session
 
@@ -91,7 +91,7 @@ class SurveyCTO:
         """
         try:
             form_details = self.session.get(
-                f"https://{self.server_name}.surveycto.com/forms/{id}/workbook/export/load",
+                f"https://{self.server_name}.surveycto.com/forms/{quote(id)}/workbook/export/load",
                 auth=self.auth_basic,
                 headers={
                     "X-csrf-token": self.csrf_token
@@ -120,7 +120,8 @@ class SurveyCTO:
         # TODO How to handle repeat groups?
         # TODO should this return repeat groups?
 
-        url = f"https://{self.server_name}.surveycto.com/api/v1/forms/data/csv/{id}"
+
+        url = f"https://{self.server_name}.surveycto.com/api/v1/forms/data/csv/{quote(id)}"
         try:
             form_submissions = self.session.get(url, auth=self.auth_basic)
             # TODO handle errors
@@ -144,7 +145,8 @@ class SurveyCTO:
             form_id (string): IF of the form
             field_name (string): Name of the repeat group field
         """
-        url = f"https://{self.server_name}.surveycto.com/api/v1/forms/data/csv/{form_id}/{field_name}"
+
+        url = f"https://{self.server_name}.surveycto.com/api/v1/forms/data/csv/{quote(form_id)}/{quote(field_name)}"
         try:
             repeat_group_submissions = self.session.get(url, auth=self.auth_basic)
         except HTTPError as e:

--- a/DAGs/helpers/surveycto.py
+++ b/DAGs/helpers/surveycto.py
@@ -71,8 +71,16 @@ class SurveyCTO:
             logger.error('Unexpected error getting list of SurveyCTO forms')
             logger.error(e)
             raise e
-
-        return forms_request.json()["forms"]
+        
+        active_forms = [
+            form for form in forms_request.json()["forms"] 
+            if (
+                not form["testForm"] and
+                form["deployed"] and
+                form["completeSubmissionCount"] > 0
+            )
+        ]
+        return active_forms
 
     def get_form(self, id):
         """Get a form's details by its ID

--- a/DAGs/helpers/surveycto.py
+++ b/DAGs/helpers/surveycto.py
@@ -3,6 +3,7 @@ import logging
 from io import StringIO
 
 import requests
+from requests.exceptions import HTTPError
 import pandas
 from requests.exceptions import HTTPError, RequestException
 
@@ -42,11 +43,11 @@ class SurveyCTO:
             res.raise_for_status()
             csrf_token = re.search(r"var csrfToken = '(.+?)';", res.text).group(1)
             return csrf_token
-        except requests.exceptions.HTTPError as e:
+        except HTTPError as e:
             logger.error('Could not load SurveyCTO landing page for getting the CSRF token')
             logger.error(e)
             raise e
-        except requests.exceptions.RequestException as e:
+        except Exception as e:
             logger.error('Unexpected error loading SurveyCTO landing page')
             logger.error(e)
             raise e
@@ -66,7 +67,7 @@ class SurveyCTO:
             logger.error('Error getting list of SurveyCTO forms')
             logger.error(e)
             raise e
-        except RequestException as e:
+        except Exception as e:
             logger.error('Unexpected error getting list of SurveyCTO forms')
             logger.error(e)
             raise e
@@ -93,7 +94,7 @@ class SurveyCTO:
             logger.error(f'Error getting details of form of ID: {id}')
             logger.error(e)
             raise e
-        except RequestException as e:
+        except Exception as e:
             logger.error(f'Unexpected error getting details of form of ID: {id}')
             logger.error(e)
             raise e
@@ -125,7 +126,7 @@ class SurveyCTO:
             logger.error(f'Error getting submissions of form of ID: {id}')
             logger.error(e)
             raise e
-        except RequestException as e:
+        except Exception as e:
             logger.error(f'Unexpected error getting submissions of form of ID: {id}')
 
     def get_repeat_group_submissions(self, form_id, field_name):
@@ -142,7 +143,7 @@ class SurveyCTO:
             logger.error(f'Error getting submissions of form of ID: {id}')
             logger.error(e)
             raise e
-        except RequestException as e:
+        except Exception as e:
             logger.error(f'Unexpected error getting submissions of form of ID: {id}')
             logger.error(e)
             raise e

--- a/DAGs/helpers/surveycto.py
+++ b/DAGs/helpers/surveycto.py
@@ -53,7 +53,9 @@ class SurveyCTO:
             raise e
 
     def get_all_forms(self):
-        """Get a list of all the forms of the SurveyCTO server
+        """
+        Get a list of all the deployed non-test forms of the SurveyCTO
+        server that have at least a submission.
         """
         try:
             forms_request = self.session.get(

--- a/DAGs/pull_survey_cto_data_csv.py
+++ b/DAGs/pull_survey_cto_data_csv.py
@@ -62,6 +62,8 @@ def import_forms_and_submissions(**kwargs):
     forms = scto_client.get_all_forms()
     logger.info(f"Found a total of {len(forms)} forms")
 
+    successfully_imported_forms = []
+
     for form in forms:
         try:
             submissions_dataframe = scto_client.get_form_submissions(form["id"])
@@ -81,10 +83,13 @@ def import_forms_and_submissions(**kwargs):
                 dataframe.to_sql(form["id"] + "___" + repeat_group["name"], db.engine, if_exists="replace")
                 logger.info(f"Saved repeat group {repeat_group['name']} of form {form['id']}")
 
-            form_details = scto_client.get_form(form["id"])
-        except:
+            successfully_imported_forms.append(form)
+        except Exception as e:
             logger.error(f"Unexpected error handling form of ID: {form['id']}. Please see previous messages.")
+            logger.error(e)
 
+    logger.info(f"Successfully imported {len(successfully_imported_forms)} form from a total of {len(forms)} forms")
+    logger.info(f"List of form IDs successfully imported: {[form['id'] for form in successfully_imported_forms]}")
 
 with DAG(DAG_NAME, default_args=default_args, schedule_interval="@daily") as dag:
 


### PR DESCRIPTION
## What is the Purpose?
Adresses #42

## What was the approach?
This was a problem since the forms with IDs were raising errors when I was trying to fetch their submissions.
None of those forms were deployed or had any submissions on them, so I simply filtered them from the list of the forms.


## Are there any concerns to addressed further before or after merging this PR?
I am now hitting a PostgreSQL limit on the length of the table name, to not exceed 63 characters.
This is a hard limit that can not be changed easily, and that can break compatibility.
This issue is even exasperated by how I currently name the tables that represent the repeat groups, and that is appending the ID of the form with that of the field `form_id__field_id`

## Mentions?
@sannleen 

## Issue(s) affected?
Resolve #42