### PR TITLE
Fix #46: table and column names longer than 63 characters

### DIFF
--- a/DAGs/helpers/surveycto.py
+++ b/DAGs/helpers/surveycto.py
@@ -45,11 +45,11 @@ class SurveyCTO:
             return csrf_token
         except HTTPError as e:
             logger.error('Could not load SurveyCTO landing page for getting the CSRF token')
-            logger.error(e)
+            logger.exception(e)
             raise e
         except Exception as e:
             logger.error('Unexpected error loading SurveyCTO landing page')
-            logger.error(e)
+            logger.exception(e)
             raise e
 
     def get_all_forms(self):
@@ -67,11 +67,11 @@ class SurveyCTO:
             )
         except HTTPError as e:
             logger.error('Error getting list of SurveyCTO forms')
-            logger.error(e)
+            logger.exception(e)
             raise e
         except Exception as e:
             logger.error('Unexpected error getting list of SurveyCTO forms')
-            logger.error(e)
+            logger.exception(e)
             raise e
         
         active_forms = [
@@ -102,11 +102,11 @@ class SurveyCTO:
             return form_details.json()
         except HTTPError as e:
             logger.error(f'Error getting details of form of ID: {id}')
-            logger.error(e)
+            logger.exception(e)
             raise e
         except Exception as e:
             logger.error(f'Unexpected error getting details of form of ID: {id}')
-            logger.error(e)
+            logger.exception(e)
             raise e
 
 
@@ -135,10 +135,10 @@ class SurveyCTO:
                 return pandas.DataFrame()
         except HTTPError as e:
             logger.error(f'Error getting submissions of form of ID: {id}')
-            logger.error(e)
+            logger.exception(e)
             raise e
         except Exception as e:
-            logger.error(f'Unexpected error getting submissions of form of ID: {id}')
+            logger.exception(f'Unexpected error getting submissions of form of ID: {id}')
 
     def get_repeat_group_submissions(self, form_id, field_name):
         """Get submission of the repeat groups
@@ -153,11 +153,11 @@ class SurveyCTO:
             repeat_group_submissions = self.session.get(url, auth=self.auth_basic)
         except HTTPError as e:
             logger.error(f'Error getting submissions of form of ID: {id}')
-            logger.error(e)
+            logger.exception(e)
             raise e
         except Exception as e:
             logger.error(f'Unexpected error getting submissions of form of ID: {id}')
-            logger.error(e)
+            logger.exception(e)
             raise e
 
         if repeat_group_submissions.status_code == 200 and repeat_group_submissions.text:

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -54,7 +54,7 @@ def clean_column_name(column_name):
     """
     # TODO Move away from this file
     if len(column_name) > 60:
-        return column_name[:55] + column_name[-5:] # Less chances of conflicting column names this way
+        return column_name[:53] + "__" + column_name[-5:] # Less chances of conflicting column names this way
     else:
         return column_name
 
@@ -108,7 +108,7 @@ def import_forms_and_submissions(**kwargs):
                     # TODO Provide details about which columns are conflicting
                     logger.error("Conflict in column names")
                 dataframe.to_sql(
-                    form["id"][:40] + "_" + repeat_group["name"][:20], # TODO Find a better/shorter name
+                    form["id"][:40] + "__" + repeat_group["name"][:20], # TODO Find a better/shorter name
                     db.engine,
                     if_exists="replace",
                 )

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -54,7 +54,7 @@ def clean_column_name(column_name):
     """
     # TODO Move away from this file
     if len(column_name) > 60:
-        return column_name[:53] + "__" + column_name[-5:] # Less chances of conflicting column names this way
+        return column_name[:50] + "__" + column_name[-5:] # Less chances of conflicting column names this way
     else:
         return column_name
 
@@ -108,7 +108,7 @@ def import_forms_and_submissions(**kwargs):
                     # TODO Provide details about which columns are conflicting
                     logger.error("Conflict in column names")
                 dataframe.to_sql(
-                    form["id"][:40] + "__" + repeat_group["name"][:20], # TODO Find a better/shorter name
+                    form["id"][:50] + "__" + repeat_group["name"][:5], # TODO Find a better/shorter name
                     db.engine,
                     if_exists="replace",
                 )

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -121,7 +121,7 @@ def import_forms_and_submissions(**kwargs):
             logger.error(
                 f"Unexpected error handling form of ID: {form['id']}. Please see previous messages."
             )
-            logger.error(e)
+            logger.exception(e)
 
     logger.info(
         f"Successfully imported {len(successfully_imported_forms)} form from a total of {len(forms)} forms"

--- a/DAGs/pull_survey_cto_data.py
+++ b/DAGs/pull_survey_cto_data.py
@@ -108,7 +108,7 @@ def import_forms_and_submissions(**kwargs):
                     # TODO Provide details about which columns are conflicting
                     logger.error("Conflict in column names")
                 dataframe.to_sql(
-                    form["id"] + "___" + repeat_group["name"],
+                    form["id"][:40] + "_" + repeat_group["name"][:20], # TODO Find a better/shorter name
                     db.engine,
                     if_exists="replace",
                 )


### PR DESCRIPTION
## What is the Purpose?
Address #46 

## What was the approach?
1. Form's IDs are truncated to 60 characters
2. If a column's name is longer 60 characters, concatenate its first 55 characters and it's last 5 characters. This is to avoid collisions since many column names differ in the very last characters.
3. Naing of repeat group tables was changed (https://github.com/hikaya-io/connectors/pull/55/files#diff-d1a5a071d857cf483f17033a806fd12568303535117869656ee0142b075058a0R111). This can lead to collision if two repeat groups exist in the same form, and have the same first 20 characters.

## Are there any concerns to addressed further before or after merging this PR?
None

## Mentions?
@sannleen 

## Issue(s) affected?
Resolve #46 